### PR TITLE
oreo bug fix, no smallIcon set in notification (#1792)

### DIFF
--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -385,10 +385,6 @@ public final class Options {
         }
 
         if (resId == 0) {
-            resId = context.getApplicationInfo().icon;
-        }
-
-        if (resId == 0) {
             resId = android.R.drawable.ic_popup_reminder;
         }
 

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -248,10 +248,6 @@ public final class AssetUtil {
     public int getResId(String resPath) {
         int resId = getResId(context.getResources(), resPath);
 
-        if (resId == 0) {
-            resId = getResId(Resources.getSystem(), resPath);
-        }
-
         return resId;
     }
 


### PR DESCRIPTION
* Update AssetUtil.java

Removing Resources.getSystem() to get resource ID because in android 8.1 (physical device) it fire an exception with the DEFALUT_ICON (res://icon) if no smallIcon is set in the notification schedule.
Changed also Options.java for small icon fallback

* Update Options.java

Removed resId = context.getApplicationInfo().icon
The application icon is set always and it is not able to select the resId = android.R.drawable.ic_popup_reminder. This is always set (API 1) and not showing ugly as app icon (notification small icon should be a silhouette)